### PR TITLE
Fixed file_exists()

### DIFF
--- a/text.c
+++ b/text.c
@@ -293,9 +293,10 @@ void save_file(PAGE *p)
 int file_exists(char *filename)
 {
     FILE *fp = fopen(filename, "r");
-    int result = (fp == NULL);
-    if(result)
+    if(fp != NULL) {
         fclose(fp);
-    return !result;
+        return 1;
+    }
+    return 0;
 }
 /* saving and loading */


### PR DESCRIPTION
There was a bug: when trying to open editor and give him nonexisting file as argument, it crashes with segfault. Now it works.
